### PR TITLE
initial draft of org rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,10 +183,11 @@
 
         var eventEmitter = new EventEmitter();
         var externalFlags = new ExternalFlags();
+        var org = new Organization();
         var deadline = new Date(2017, 8, 9);
 
-        var initialForm = externalFlags.hasFlag("call") ? "call" : "action";
-        var persistentButtonText = externalFlags.hasFlag("call") ? "Call Congress" : "Send Letter";
+        var initialForm = externalFlags.has('call') ? 'call' : 'action';
+        var persistentButtonText = externalFlags.has('call') ? 'Call Congress' : "Send Letter";
 
         mountComponent(
           React.createElement(BFTNFormFlow, {
@@ -195,7 +196,7 @@
             actionUrl: "http://localhost:8000/action",
             callUrl: "http://localhost:8000/create",
             initialForm: initialForm,
-            org: externalFlags.getFlag("org", "fftf"),
+            org: org,
             deadline: deadline
           }),
           document.getElementById("bftn-action-form")

--- a/ts/bftn-form-flow.tsx
+++ b/ts/bftn-form-flow.tsx
@@ -16,11 +16,11 @@ import {CallActionForm} from './call-action-form';
 import {PetitionCopy} from './petition-copy';
 import {PetitionForm} from './petition-form';
 import {r} from './r';
-
+import {Organization} from './organization';
 
 interface Props {
 	initialForm: string
-	org: string
+	org: Organization
 	actionUrl: string
 	callUrl: string
 	deadline: Date
@@ -29,6 +29,7 @@ interface Props {
 
 interface State {
 	modal: string | null
+	org: Organization
 }
 
 
@@ -36,7 +37,8 @@ export class BFTNFormFlow extends React.Component<Props, State> {
 	constructor(props: Props) {
 		super(props);
 		this.state = {
-			modal: null
+			modal: null,
+            org: props.org
 		};
 	}
 	setModal(modal: string | null): any {
@@ -54,7 +56,7 @@ export class BFTNFormFlow extends React.Component<Props, State> {
 				break;
 			case "petition":
 			default:
-				form = <PetitionForm org={this.props.org} url={this.props.actionUrl} setModal={this.setModal.bind(this)} />;
+				form = <PetitionForm org={this.state.org.getOrg()} url={this.props.actionUrl} setModal={this.setModal.bind(this)} />;
 				copy = <PetitionCopy deadline={this.props.deadline} />
 				break;
 		}

--- a/ts/bootstrap.tsx
+++ b/ts/bootstrap.tsx
@@ -16,6 +16,7 @@ import {BFTNFormFlow} from './bftn-form-flow';
 import {mountComponent} from './utils';
 import {ExternalFlags} from './external-flags';
 import {GoogleAnalytics} from './google-analytics';
+import {Organization} from './organization';
 
 declare var window: any;
 
@@ -34,3 +35,4 @@ window['BFTNFormFlow'] = BFTNFormFlow;
 window['mountComponent'] = mountComponent;
 window['ExternalFlags'] = ExternalFlags;
 window['GoogleAnalytics'] = GoogleAnalytics;
+window['Organization'] = Organization;

--- a/ts/disclaimer.tsx
+++ b/ts/disclaimer.tsx
@@ -1,0 +1,26 @@
+/// <reference path="../typings/index.d.ts" />
+
+import * as React from 'react';
+
+import {Organization} from './organization';
+
+interface Props {
+}
+
+interface State {
+  org: Organization
+}
+
+export class Disclaimer extends React.Component<Props, State> {
+	constructor(props: Props) {
+		super(props);
+        this.state = {
+          org: new Organization()
+        }
+	}
+    render() {
+      return (
+        <span className="note"><a href="{ this.state.org.getURL() }">{ this.state.org.getName() }</a> will contact you about future campaigns. <a href="https://www.battleforthenet.com/privacy/" className="privacy-policy-link">Privacy Policy</a></span>
+      );
+    }
+}

--- a/ts/external-flags.tsx
+++ b/ts/external-flags.tsx
@@ -6,11 +6,12 @@ export class ExternalFlags {
 		this.params = new URLSearchParams(window.location.search.substring(1));
 	}
 
-	hasFlag(flag: string) {
+	has(flag: string) {
 		return !!this.params.get(flag);
 	}
 
-	getFlag(flag: string, defaultValue: any) {
-		return this.params.get(flag) || defaultValue;
+	get(flag: string) {
+        // TODO: This should probably return undefined if the param does not exist?
+		return this.params.get(flag) || '';
 	}
 }

--- a/ts/organization.tsx
+++ b/ts/organization.tsx
@@ -1,0 +1,68 @@
+/// <reference path="../typings/index.d.ts" />
+
+import {ExternalFlags} from './external-flags';
+
+interface State {
+  org: string
+  name: string
+  url: string
+}
+
+function randomOrg() {
+  var coinToss = Math.random();
+
+  if (coinToss < .20) {
+    return 'fp';
+  } else if (coinToss < .60) {
+    return 'dp';
+  } else {
+    return 'fftf';
+  }
+}
+
+export class Organization {
+    state: State
+
+	constructor() {
+      var params = new ExternalFlags();
+      this.set(params.has('org') ? params.get('org') : 'fftf');
+	}
+
+    set(org: string) {
+      switch(org) {
+        case 'dp':
+          this.state = {
+            org: 'dp',
+            name: 'Demand Progress',
+            url: 'https://demandprogress.org/'
+          }
+          break;
+        case 'fp':
+          this.state = {
+            org: 'fp',
+            name: 'Free Press',
+            url: 'https://www.freepress.net/'
+          }
+          break;
+        case 'fftf':
+        default:
+          this.state = {
+            org: 'fftf',
+            name: 'Fight for the Future',
+            url: 'https://www.fightforthefuture.org/'
+          }
+      }
+    }
+
+    getOrg() {
+      return this.state.org;
+    }
+
+    getName() {
+      return this.state.name;
+    }
+
+    getURL() {
+      return this.state.url;
+    }
+}


### PR DESCRIPTION
Initial draft of porting over the org rotation functionality, this definitely needs a review and probably some cleanup, and the `Disclaimer` component isn't actually wired into `PetitionForm` yet (but should be!)

Not sure if it would be more logical to combine `Disclaimer` and `Organization` and add `renderInput` for the `name="org"` input and `renderDisclaimer` methods instead of the current functionality?

/cc @sirpengi 